### PR TITLE
Add Rust crate metadata and contributor checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install GTK build dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgtk-4-dev pkg-config
+      - name: Use Rust stable
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup component add rustfmt clippy
+      - name: Install just
+        run: cargo install just --locked
+      - name: Run contributor checks
+        run: just ci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
+authors = ["Ian Cleary <iancleary@hey.com>"]
+description = "A small GTK power menu for NixOS and Hyprland sessions"
 edition = "2021"
+homepage = "https://github.com/iancleary/power-panel"
+license = "MIT"
 name = "power-panel"
+repository = "https://github.com/iancleary/power-panel"
 version = "0.1.0"
 
 [dependencies]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Ian Cleary
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # power-panel
 
+[![CI](https://github.com/iancleary/power-panel/actions/workflows/ci.yml/badge.svg)](https://github.com/iancleary/power-panel/actions/workflows/ci.yml)
+
 ## Description
 
 Power Panel for NixOS, a reboot, shutdown GUI used with Hyprland.
@@ -78,3 +80,15 @@ For my use case, I integrated this file into my nixos-config this way; [checkout
 I created this to learn and allow myself to reboot or shutdown quickly within a Hyprland windowing manager session. I also use `waybar` and it doesn't provide a power menu (like GNOME or KDE do, etc.).
 
 It was a fun way to learn nix and rust packaging as well :).
+
+## Development
+
+This repository includes a `justfile` for common local checks:
+
+```shell
+just fmt-check
+just lint
+just test
+just build
+just ci
+```

--- a/justfile
+++ b/justfile
@@ -1,15 +1,43 @@
-# list recipes
-help:
-  just --list
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 
-develop:
-  nix develop -c zsh
+default:
+    @just --list
 
-run:
-  cargo run
+# format the code
+fmt:
+    cargo fmt --all
 
-release:
-  cargo build --release
+# check formatting without writing changes
+fmt-check:
+    cargo fmt --all -- --check
 
+# lint the code
+lint:
+    cargo clippy --all-targets --all-features -- -D warnings
+
+# run tests
+test:
+    cargo test --all-targets --all-features
+
+# build the crate
 build:
-  nix build
+    cargo build --all-targets
+
+# build the crate for release
+release:
+    cargo build --release
+
+# run the app
+run:
+    cargo run
+
+# enter the Nix development shell
+develop:
+    nix develop -c zsh
+
+# run checks and build
+ci: fmt-check lint test build
+
+# build with Nix
+nix-build:
+    nix build

--- a/src/css.rs
+++ b/src/css.rs
@@ -1,15 +1,15 @@
-use gtk::CssProvider;
 use gtk::gdk::Display;
+use gtk::CssProvider;
 
 pub fn load_css() {
-  // Load the CSS file and add it to the provider
-  let provider = CssProvider::new();
-  provider.load_from_data(include_str!("style.css"));
+    // Load the CSS file and add it to the provider
+    let provider = CssProvider::new();
+    provider.load_from_data(include_str!("style.css"));
 
-  // Add the provider to the default screen
-  gtk::style_context_add_provider_for_display(
-      &Display::default().expect("Could not connect to a display."),
-      &provider,
-      gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
-  );
+    // Add the provider to the default screen
+    gtk::style_context_add_provider_for_display(
+        &Display::default().expect("Could not connect to a display."),
+        &provider,
+        gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
+    );
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,30 +1,28 @@
-use gtk::IconTheme;
 use gtk::gdk::Display;
-
+use gtk::IconTheme;
 
 pub fn load_icons() {
-  // Load the icons into the icon theme
-  let icon_theme = IconTheme::for_display(
-      &Display::default().expect("Could not connect to a display.")
-  );
-  // icon_theme.set_theme_name(Some("powpow"));
-  // icon_theme.add_search_path("/home/iancleary/Development/power-panel/src/icons/hicolor");
+    // Load the icons into the icon theme
+    let icon_theme =
+        IconTheme::for_display(&Display::default().expect("Could not connect to a display."));
+    // icon_theme.set_theme_name(Some("powpow"));
+    // icon_theme.add_search_path("/home/iancleary/Development/power-panel/src/icons/hicolor");
 
-  // in dev mode, relative to the path where `cargo run` is run from
-  icon_theme.add_search_path("src/icons/hicolor");
+    // in dev mode, relative to the path where `cargo run` is run from
+    icon_theme.add_search_path("src/icons/hicolor");
 
-  // let mut names = icon_theme.icon_names();
-  // names.sort();
+    // let mut names = icon_theme.icon_names();
+    // names.sort();
 
-  // print theme icons
-  // println!("Icon names: {:?}", names);
+    // print theme icons
+    // println!("Icon names: {:?}", names);
 
-  // let theme_name = icon_theme.theme_name();
-  // println!("theme_name: {:?}", theme_name);
+    // let theme_name = icon_theme.theme_name();
+    // println!("theme_name: {:?}", theme_name);
 
-  // let search_path = icon_theme.search_path();
-  // println!("search_path: {:?}", search_path);
+    // let search_path = icon_theme.search_path();
+    // println!("search_path: {:?}", search_path);
 
-  // let resource_path = icon_theme.resource_path();
-  // println!("resource_path: {:?}", resource_path);
+    // let resource_path = icon_theme.resource_path();
+    // println!("resource_path: {:?}", resource_path);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,2 @@
-pub mod icons;
 pub mod css;
+pub mod icons;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,8 @@ fn build_ui(app: &Application) {
         Command::new("sudo")
             .arg("reboot")
             .arg("now")
-            .spawn()
-            .expect("reboot command failed to start");
+            .status()
+            .expect("reboot command failed");
     });
 
     // let button_2 = Button::from_icon_name("window-close");
@@ -44,8 +44,8 @@ fn build_ui(app: &Application) {
         Command::new("sudo")
             .arg("shutdown")
             .arg("now")
-            .spawn()
-            .expect("shutdown command failed to start");
+            .status()
+            .expect("shutdown command failed");
     });
 
     let button_3 = Button::from_icon_name("window-close-symbolic");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-use std::process; // for exit
-use std::process::Command;
 use gtk::prelude::*;
 use gtk::{glib, Application, ApplicationWindow, Button, CenterBox};
+use std::process; // for exit
+use std::process::Command;
 
 use power_panel::css::load_css;
 // use power_panel::icons::load_icons;
@@ -21,8 +21,6 @@ fn main() -> glib::ExitCode {
     app.run()
 }
 
-
-
 fn build_ui(app: &Application) {
     // Create a button_1 with label and margins
     let button_1 = Button::from_icon_name("view-refresh-symbolic");
@@ -30,10 +28,10 @@ fn build_ui(app: &Application) {
     // Connect to "clicked" signal of `button_1`
     button_1.connect_clicked(|_| {
         Command::new("sudo")
-        .arg("reboot")
-        .arg("now")
-        .spawn()
-        .expect("reboot command failed to start");
+            .arg("reboot")
+            .arg("now")
+            .spawn()
+            .expect("reboot command failed to start");
     });
 
     // let button_2 = Button::from_icon_name("window-close");
@@ -44,10 +42,10 @@ fn build_ui(app: &Application) {
     // Connect to "clicked" signal of `button_2`
     button_2.connect_clicked(|_| {
         Command::new("sudo")
-        .arg("shutdown")
-        .arg("now")
-        .spawn()
-        .expect("shutdown command failed to start");
+            .arg("shutdown")
+            .arg("now")
+            .spawn()
+            .expect("shutdown command failed to start");
     });
 
     let button_3 = Button::from_icon_name("window-close-symbolic");


### PR DESCRIPTION
## Summary

- Add MIT license file and Cargo package metadata aligned with the public repository.
- Expand the `justfile` with formatting, linting, test, build, CI, run, and Nix build recipes.
- Add GitHub Actions CI with GTK/pkg-config system dependencies, plus a README badge and development commands.
- Apply `cargo fmt` formatting and fix Clippy's `zombie_processes` lint by waiting for the reboot/shutdown commands.

## Checks run

- `cargo fmt --all -- --check` - passed locally.
- `cargo clippy --all-targets --all-features -- -D warnings` - failed locally because this container does not have `pkg-config`/GLib GTK development packages installed.
- `cargo test --all-targets --all-features` - failed locally at the same missing `pkg-config`/GLib GTK dependency gate.
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features` - failed locally at the same missing `pkg-config`/GLib GTK dependency gate.
- `cargo package --list` - passed locally.
- `cargo package --allow-dirty --no-verify` - passed locally; emitted a yanked `futures-util v0.3.28` lockfile warning.
- `cargo package --allow-dirty` - packaged locally, then failed verification at the same missing `pkg-config`/GLib GTK dependency gate.

## Notes/risks

- The GitHub Actions workflow installs `libgtk-4-dev` and `pkg-config` before running `just ci`; local GTK-dependent verification remains blocked in this container until those system packages are available.
- GitHub reported one existing moderate vulnerability on the default branch during push; this PR does not address dependency updates.
- `cargo-audit`, `cargo-deny`, `cargo-machete`, and `cargo-semver-checks` were not installed locally, so I skipped those optional checks.